### PR TITLE
Implement daemon-provided frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,8 @@
 
 ## [Unreleased]
 - Initial project scaffolding
+- Daemon periodically signals Hyprlock with SIGUSR2
+- FPS can be adjusted with `mode fps`
+- State shared via `state.json` between CLI and daemon
+- CLI updates are sent to the daemon over a Unix socket
+- `next-image` retrieves frames from the daemon

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,9 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "proptest",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -195,6 +198,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -442,6 +451,44 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ resolver = "2"
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 proptest = "1"
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 This project modulates bongo cat intensity on the Hyprlock lockscreen.
 
-The daemon sends `SIGUSR2` to Hyprlock so it refreshes its image element.
-Hyprlock retrieves frames by running `bongo-modulator next-image` which outputs
-the path to a frame from the images directory.
+The daemon periodically sends `SIGUSR2` to Hyprlock so it refreshes its image
+element. Hyprlock retrieves frames by running `bongo-modulator next-image`
+which requests the next frame from the daemon over the Unix socket.
+Configuration is persisted in `state.json` and updates are sent to the daemon
+so changes take effect immediately.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,95 @@
 use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::Shutdown;
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU32, Ordering},
+    Arc, Mutex,
+};
+use std::time::Duration;
+use std::{env, fs};
 use tracing::{error, info};
+
+fn config_path() -> PathBuf {
+    env::var_os("BONGO_STATE_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("state.json"))
+}
+
+fn load_config() -> Config {
+    let path = config_path();
+    if let Ok(data) = fs::read(&path) {
+        if let Ok(cfg) = serde_json::from_slice(&data) {
+            return cfg;
+        }
+    }
+    Config::default()
+}
+
+fn save_config(cfg: &Config) {
+    let path = config_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(data) = serde_json::to_vec(cfg) {
+        if let Err(e) = fs::write(&path, data) {
+            error!("failed to write config: {e}");
+        }
+    } else {
+        error!("failed to encode config");
+    }
+}
+
+fn socket_path() -> PathBuf {
+    env::var_os("BONGO_SOCKET")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp/bongo.sock"))
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum ControlMessage {
+    SetFps(u32),
+    EnableAi,
+    NextImage { dir: PathBuf },
+}
+fn send_command(msg: ControlMessage) -> std::io::Result<Option<String>> {
+    let path = socket_path();
+    match UnixStream::connect(&path) {
+        Ok(mut stream) => {
+            serde_json::to_writer(&mut stream, &msg)?;
+            stream.flush()?;
+            let _ = stream.shutdown(Shutdown::Write);
+
+            if matches!(msg, ControlMessage::NextImage { .. }) {
+                let mut buf = String::new();
+                stream.read_to_string(&mut buf)?;
+                Ok(Some(buf))
+            } else {
+                Ok(None)
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Config {
+    fps: u32,
+    ai_mode: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            fps: 5,
+            ai_mode: false,
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -57,26 +146,113 @@ pub fn execute(cli: Cli) {
 
 fn run_daemon() {
     info!("daemon started");
-    // TODO: detect hyprlock and send SIGUSR2 periodically
+
+    let cfg = load_config();
+    let fps = Arc::new(AtomicU32::new(cfg.fps.max(1)));
+    let ai_mode = Arc::new(AtomicBool::new(cfg.ai_mode));
+
+    let sock_path = socket_path();
+    let _ = fs::remove_file(&sock_path);
+    let listener = match UnixListener::bind(&sock_path) {
+        Ok(l) => l,
+        Err(e) => {
+            error!("failed to bind socket: {e}");
+            return;
+        }
+    };
+
+    let fps_ctrl = fps.clone();
+    let ai_ctrl = ai_mode.clone();
+    let indexes: Arc<Mutex<HashMap<PathBuf, usize>>> = Arc::new(Mutex::new(HashMap::new()));
+    let idx_ctrl = indexes.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(mut s) => {
+                    if let Ok(msg) = serde_json::from_reader::<_, ControlMessage>(&mut s) {
+                        match msg {
+                            ControlMessage::SetFps(v) => {
+                                fps_ctrl.store(v.max(1), Ordering::Relaxed)
+                            }
+                            ControlMessage::EnableAi => ai_ctrl.store(true, Ordering::Relaxed),
+                            ControlMessage::NextImage { dir } => {
+                                let reply = {
+                                    let mut idx = idx_ctrl.lock().unwrap();
+                                    let entry = idx.entry(dir.clone()).or_default();
+                                    match std::fs::read_dir(&dir) {
+                                        Ok(rd) => {
+                                            let mut paths: Vec<PathBuf> = rd
+                                                .filter_map(|e| e.ok())
+                                                .filter(|e| e.path().is_file())
+                                                .map(|e| e.path())
+                                                .collect();
+                                            paths.sort();
+                                            if !paths.is_empty() {
+                                                let path = paths[*entry % paths.len()].clone();
+                                                *entry = (*entry + 1) % paths.len();
+                                                Some(path)
+                                            } else {
+                                                None
+                                            }
+                                        }
+                                        Err(_) => None,
+                                    }
+                                };
+                                if let Some(p) = reply {
+                                    let _ = s.write_all(p.to_string_lossy().as_bytes());
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => error!("failed to accept connection: {e}"),
+            }
+        }
+    });
+
+    loop {
+        if let Err(e) = Command::new("pkill")
+            .args(["-SIGUSR2", "hyprlock"])
+            .status()
+        {
+            error!("failed to signal hyprlock: {e}");
+        }
+        let delay = fps.load(Ordering::Relaxed);
+        std::thread::sleep(Duration::from_secs_f64(1.0 / delay as f64));
+    }
+}
+
+pub fn next_image_path(dir: PathBuf) -> Option<PathBuf> {
+    match send_command(ControlMessage::NextImage { dir }) {
+        Ok(Some(p)) if !p.is_empty() => Some(PathBuf::from(p)),
+        _ => None,
+    }
 }
 
 fn next_image(dir: PathBuf) {
-    match std::fs::read_dir(&dir).and_then(|mut entries| {
-        entries
-            .find(|res| res.as_ref().map(|e| e.path().is_file()).unwrap_or(false))
-            .map(|res| res.map(|e| e.path()))
-            .transpose()
-    }) {
-        Ok(Some(path)) => println!("{}", path.display()),
-        Ok(None) => error!("no images found in {}", dir.display()),
-        Err(e) => error!("failed to read {dir:?}: {e}", dir = dir, e = e),
+    match next_image_path(dir) {
+        Some(path) => println!("{}", path.display()),
+        None => error!("daemon did not return an image"),
     }
 }
 
 fn enable_ai() {
+    let mut cfg = load_config();
+    cfg.ai_mode = true;
+    save_config(&cfg);
+    let _ = send_command(ControlMessage::EnableAi);
     info!("AI mode enabled (stub)");
 }
 
 fn set_fps(fps: u32) {
+    let mut cfg = load_config();
+    cfg.fps = fps;
+    save_config(&cfg);
+    let _ = send_command(ControlMessage::SetFps(fps));
     info!("manual fps set to {fps}");
+}
+
+/// Returns the currently configured FPS.
+pub fn current_fps() -> u32 {
+    load_config().fps
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,17 @@
-use bongo_modulator::{Cli, Commands, ModeSubcommand};
+use bongo_modulator::{current_fps, execute, Cli, Commands, ModeSubcommand};
 use clap::Parser;
 use proptest::prelude::*;
+use std::io::Write;
+use std::os::unix::net::UnixListener;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+#[derive(serde::Deserialize, Debug, PartialEq)]
+enum ControlMessage {
+    SetFps(u32),
+    EnableAi,
+    NextImage { dir: PathBuf },
+}
 
 proptest! {
     #[test]
@@ -12,4 +23,53 @@ proptest! {
             _ => prop_assert!(false, "unexpected subcommand"),
         }
     }
+
+    #[test]
+    fn execute_sets_fps(value in 1u32..30) {
+        let dir = tempdir().unwrap();
+        std::env::set_var("BONGO_STATE_PATH", dir.path().join("state.json"));
+        let socket = dir.path().join("sock");
+        std::env::set_var("BONGO_SOCKET", &socket);
+
+        let listener = UnixListener::bind(&socket).unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            serde_json::from_reader::<_, ControlMessage>(&mut stream).unwrap()
+        });
+
+        let cli = Cli {
+            command: Commands::Mode {
+                mode: ModeSubcommand::Fps { fps: value },
+            },
+        };
+        execute(cli);
+
+        let received = handle.join().unwrap();
+        prop_assert_eq!(received, ControlMessage::SetFps(value));
+        prop_assert_eq!(current_fps(), value);
+    }
+}
+
+#[test]
+fn next_image_uses_daemon() {
+    let dir = tempdir().unwrap();
+    let socket = dir.path().join("sock");
+    std::env::set_var("BONGO_SOCKET", &socket);
+
+    let listener = UnixListener::bind(&socket).unwrap();
+    let img_path = dir.path().join("img.png");
+    let return_path = img_path.clone();
+    let server_dir = PathBuf::from("images");
+    let handle = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let msg: ControlMessage = serde_json::from_reader(&mut stream).unwrap();
+        assert_eq!(msg, ControlMessage::NextImage { dir: server_dir });
+        stream
+            .write_all(return_path.to_string_lossy().as_bytes())
+            .unwrap();
+    });
+
+    let result = bongo_modulator::next_image_path(PathBuf::from("images"));
+    handle.join().unwrap();
+    assert_eq!(result.unwrap(), img_path);
 }


### PR DESCRIPTION
## Summary
- fetch next-image from daemon over Unix socket
- ensure the daemon serves frame paths
- update README and changelog
- test daemon frame retrieval

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684b0444ec24832da711c863fbad8981