### PR TITLE
Update README and handle empty frame dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This project modulates bongo cat intensity on the Hyprlock lockscreen.
 
 The daemon periodically sends `SIGUSR2` to Hyprlock so it refreshes its image
 element. Hyprlock retrieves frames by running `bongo-modulator next-image`
-which requests the next frame from the daemon over the Unix socket.
+which requests the next frame from the daemon over the Unix socket. The daemon
+maintains its own list of frames, read from a directory named `images/` by
+default. You can point `next-image` at a different folder with `--dir` and the
+daemon will use that directory instead. If the chosen directory is empty or
+missing the daemon returns no path and `next-image` reports an error.
 Configuration is persisted in `state.json` and updates are sent to the daemon
 so changes take effect immediately.
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,4 @@
-use bongo_modulator::{current_fps, execute, Cli, Commands, ModeSubcommand};
+use bongo_modulator::{current_fps, execute, pick_frame, Cli, Commands, ModeSubcommand};
 use clap::Parser;
 use proptest::prelude::*;
 use std::io::Write;
@@ -72,4 +72,12 @@ fn next_image_uses_daemon() {
     let result = bongo_modulator::next_image_path(PathBuf::from("images"));
     handle.join().unwrap();
     assert_eq!(result.unwrap(), img_path);
+}
+
+#[test]
+fn pick_frame_empty_directory() {
+    let dir = tempdir().unwrap();
+    let mut index = 0usize;
+    let result = pick_frame(dir.path(), &mut index);
+    assert!(result.is_none());
 }


### PR DESCRIPTION
## Summary
- mention default `images/` directory and --dir override in README
- log an error when the daemon finds no frames in the directory
- expose helper `pick_frame` and test empty directory behaviour

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684b0e281714832db9dee834e4b3464d