### PR TITLE
Ensure daemon manages frame directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The daemon periodically sends `SIGUSR2` to Hyprlock so it refreshes its image
 element. Hyprlock retrieves frames by running `bongo-modulator next-image`
 which requests the next frame from the daemon over the Unix socket. The daemon
 maintains its own list of frames, read from a directory named `images/` by
-default. You can point `next-image` at a different folder with `--dir` and the
-daemon will use that directory instead. If the chosen directory is empty or
+default. You can point the daemon at a different folder with `--dir` or by
+setting `BONGO_IMAGE_DIR` in the environment. If the chosen directory is empty or
 missing the daemon returns no path and `next-image` reports an error.
 Configuration is persisted in `state.json` and updates are sent to the daemon
 so changes take effect immediately.


### PR DESCRIPTION
## Summary
- stop sending directory in `next-image`
- daemon reads frame directory from `BONGO_IMAGE_DIR`
- daemon command can override directory with `--dir`
- update README for new behaviour
- adjust tests for simplified protocol

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684b199a9dac832d865042e466895e82