### PR TITLE
Add process waiting and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ maintains its own list of frames, read from a directory named `images/` by
 default. You can point the daemon at a different folder with `--dir` or by
 setting `BONGO_IMAGE_DIR` in the environment. If the chosen directory is empty or
 missing the daemon returns no path and `next-image` reports an error.
+The daemon assumes the Hyprlock process name is `hyprlock`; override it with
+`--process` when needed.
 Configuration is persisted in `state.json` and updates are sent to the daemon
 so changes take effect immediately.
 
@@ -16,6 +18,7 @@ so changes take effect immediately.
 
 ```bash
 bongo-modulator daemon       # start the signalling service
+bongo-modulator daemon --process hyprlock  # custom process name
 bongo-modulator next-image   # print path to next frame
 bongo-modulator mode ai      # enable AI mode (stub)
 bongo-modulator mode fps 10  # set manual FPS

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -37,6 +37,19 @@ proptest! {
     }
 
     #[test]
+    fn parse_daemon_process(name in "[a-zA-Z0-9][a-zA-Z0-9_-]*") {
+        let args = ["bongo-modulator", "daemon", "--process", &name];
+        let cli = Cli::parse_from(&args);
+        match cli.command {
+            Commands::Daemon { dir, process } => {
+                prop_assert!(dir.is_none());
+                prop_assert_eq!(process, name);
+            }
+            _ => prop_assert!(false, "unexpected subcommand"),
+        }
+    }
+
+    #[test]
     fn execute_sets_fps(value in 1u32..30) {
         let dir = tempdir().unwrap();
         std::env::set_var("BONGO_STATE_PATH", dir.path().join("state.json"));


### PR DESCRIPTION
## Summary
- document daemon `--process` flag in README
- wait for hyprlock with new `wait_for_process`
- test CLI `--process` parsing

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684b265f3e08832db8a14a282482ca34