### PR TITLE
Fix daemon wait when process exits

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -117,11 +117,11 @@ pub fn run_daemon(dir: Option<PathBuf>, process: String) {
                     Some(true) => true,
                     Some(false) => {
                         error!(pid = pid.as_u32(), "failed to send signal");
-                        true
+                        false
                     }
                     None => {
                         error!("signal not supported");
-                        true
+                        false
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
- stop keeping a PID when signalling fails

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`

------
https://chatgpt.com/codex/tasks/task_e_684b28b9a16c832daf2bf60f45cabd61