### PR TITLE
Fix spurious signalling after process exit

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -113,15 +113,18 @@ pub fn run_daemon(dir: Option<PathBuf>, process: String) {
 
         pids.retain(|pid| {
             if let Some(proc_) = sys.process(*pid) {
+                if proc_.name() != std::ffi::OsStr::new(&process) {
+                    return false;
+                }
                 match proc_.kill_with(Signal::User2) {
                     Some(true) => true,
                     Some(false) => {
                         error!(pid = pid.as_u32(), "failed to send signal");
-                        true
+                        false
                     }
                     None => {
                         error!("signal not supported");
-                        true
+                        false
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
- verify PID belongs to the target process before sending SIGUSR2

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684b28b9a16c832daf2bf60f45cabd61