### PR TITLE
Improve socket path handling

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -13,9 +13,13 @@ pub enum ControlMessage {
 }
 
 pub fn socket_path() -> PathBuf {
-    env::var_os("BONGO_SOCKET")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/tmp/bongo.sock"))
+    if let Some(path) = env::var_os("BONGO_SOCKET") {
+        PathBuf::from(path)
+    } else if let Some(dir) = env::var_os("XDG_RUNTIME_DIR") {
+        PathBuf::from(dir).join("bongo.sock")
+    } else {
+        env::temp_dir().join("bongo.sock")
+    }
 }
 
 pub fn send_command(msg: ControlMessage) -> io::Result<Option<String>> {

--- a/tests/ipc.rs
+++ b/tests/ipc.rs
@@ -1,0 +1,26 @@
+use bongo_modulator::ipc::socket_path;
+use tempfile::tempdir;
+
+#[test]
+fn socket_uses_env_variable() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("sockenv");
+    std::env::set_var("BONGO_SOCKET", &path);
+    std::env::remove_var("XDG_RUNTIME_DIR");
+    assert_eq!(socket_path(), path);
+}
+
+#[test]
+fn socket_uses_runtime_dir() {
+    let dir = tempdir().unwrap();
+    std::env::remove_var("BONGO_SOCKET");
+    std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+    assert_eq!(socket_path(), dir.path().join("bongo.sock"));
+}
+
+#[test]
+fn socket_falls_back_to_tempdir() {
+    std::env::remove_var("BONGO_SOCKET");
+    std::env::remove_var("XDG_RUNTIME_DIR");
+    assert_eq!(socket_path(), std::env::temp_dir().join("bongo.sock"));
+}


### PR DESCRIPTION
## Summary
- prefer `XDG_RUNTIME_DIR` for socket location
- default to the system temp dir when runtime dir is not set
- add tests for new socket path logic

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684c1745b35c832d9aef60f5acd27261