### PR TITLE
Add systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ bongo-modulator mode ai      # enable AI mode (YOLOv8)
 bongo-modulator mode fps 10  # set manual FPS
 ```
 
+A `bongo-modulator.service` unit is included for running the daemon under
+systemd. Enable it with `systemctl enable --now bongo-modulator.service`.
+
 See `AGENTS.md` for contribution guidelines and `CHANGELOG.md` for release
 notes.
 

--- a/bongo-modulator.service
+++ b/bongo-modulator.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Bongo Modulator daemon
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/bongo-modulator daemon
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,43 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
 
   outputs = { self, nixpkgs }:
-    let pkgs = nixpkgs.legacyPackages.x86_64-linux; in {
-      devShells.x86_64-linux.default = pkgs.mkShell {
-        buildInputs = [ pkgs.rustc pkgs.cargo pkgs.pkg-config ];
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      packages.${system}.default = pkgs.rustPlatform.buildRustPackage {
+        pname = "bongo-modulator";
+        version = "0.1.0";
+        src = self;
+        cargoLock.lockFile = ./Cargo.lock;
+        nativeBuildInputs = [ pkgs.pkg-config pkgs.protobuf ];
+        postInstall = ''
+          mkdir -p $out/lib/systemd/system
+          cat > $out/lib/systemd/system/bongo-modulator.service <<EOF
+          [Unit]
+          Description=Bongo Modulator daemon
+          After=network.target
+
+          [Service]
+          ExecStart=$out/bin/bongo-modulator daemon
+          Restart=on-failure
+
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+        '';
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [
+          pkgs.rustc
+          pkgs.cargo
+          pkgs.clippy
+          pkgs.rustfmt
+          pkgs.cargo-nextest
+          pkgs.pkg-config
+          pkgs.protobuf
+        ];
       };
     };
 }


### PR DESCRIPTION
## Summary
- install bongo-modulator systemd unit during build
- include the unit file for non-Nix setups
- mention the unit in README

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684c1947d288832d81a8b89c183a039b