### PR TITLE
Fix build with nix-managed headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 - Commit messages should be in imperative mood and under 72 characters.
 - Run `cargo clippy -- -D warnings` and `cargo nextest run` before commit.
 - Prefer writing property tests with `proptest` when applicable.
+- Use only the tools provided by `nix develop`. Run all commands inside the Nix
+  shell so dependencies come from the flake.
 - Ensure the Nix flake stays in sync with project dependencies.
 - Target POSIX-compliant systems only (Linux and macOS). Windows is unsupported.
 - Camera capture should use the `nokhwa` crate for Linux and macOS.

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,44 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1749782305,
+        "narHash": "sha256-h6jWS89SZyI5ACe/Ac2Yn7Qf+Uhb1yawbtpEqgV1h8E=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dc62b7639a9dcab4ab1246876fd0df8412a4a824",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
         ];
         buildInputs = [ pkgs.llvmPackages.libclang pkgs.libv4l ];
         LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.linuxHeaders}/include -I${pkgs.glibc.dev}/include";
         postInstall = ''
           mkdir -p $out/lib/systemd/system
           cat > $out/lib/systemd/system/bongo-modulator.service <<EOF
@@ -58,6 +59,7 @@
           pkgs.libv4l
         ];
         LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.linuxHeaders}/include -I${pkgs.glibc.dev}/include";
       };
     };
 }


### PR DESCRIPTION
## Summary
- instruct contributors to use `nix develop`
- provide clang include paths in the flake

## Testing
- `nix develop --command cargo clippy -- -D warnings`
- `nix develop --command cargo nextest run`
- `nix develop --command cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684c95d6d5b8832d8efb21c1bb2b042b