### PR TITLE
Update AGENTS instructions for cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@
 - Use only the tools provided by `nix develop`. Run all commands inside the Nix
   shell so dependencies come from the flake.
 - Ensure the Nix flake stays in sync with project dependencies.
+- After building, push the resulting store paths to Cachix with
+  `cachix push bongo-modulator`.
 - Target POSIX-compliant systems only (Linux and macOS). Windows is unsupported.
 - Camera capture should use the `nokhwa` crate for Linux and macOS.
 - Building `nokhwa` requires `libclang`. Ensure it is available and that the


### PR DESCRIPTION
## Summary
- document using `cachix push bongo-modulator` when pushing build artifacts

## Testing
- `nix develop -c cargo fmt`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684c9e446e8c832da67b34bf708cf138