### PR TITLE
Add Nix checks for clippy and nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: nix develop --command cargo fmt --all -- --check
 
       - name: Lint
-        run: nix develop --command cargo clippy -- -D warnings
+        run: nix build .#clippyCheck
 
       - name: Test
-        run: nix develop --command cargo nextest run
+        run: nix build .#nextestCheck


### PR DESCRIPTION
## Summary
- extend flake outputs with clippyCheck and nextestCheck
- expose those checks as top-level outputs
- run the checks in CI using `nix build`

## Testing
- `nix develop -c cargo fmt --all`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo nextest run`
- `nix build .#clippyCheck` *(fails: Could not connect to server)*
- `nix flake check` *(fails: Could not connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_684d3c7ed388832d868640a0b49c554a