### PR TITLE
Update YOLO model defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ notes.
 
 To use AI-based FPS modulation, set the `BONGO_YOLO_MODEL` environment variable
 to the desired model filename. If the file does not exist locally the daemon
-automatically downloads it from the Hugging Face hub. The repository can be
-overridden with `BONGO_YOLO_REPO` (defaults to `ultralytics/yolov8n`). The
+automatically downloads it from the Hugging Face hub (defaults to
+`onnx_model.onnx` from `NaveenKumar5/Yolov8n-onnx-export`). The repository can
+be overridden with `BONGO_YOLO_REPO`. The
 daemon captures frames with the `nokhwa` crate (camera index `0`) and uses the
 model via the pure-Rust `candle` runtime to estimate how many people are in
 front of the camera. The FPS value is updated based on the detection results.

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -40,9 +40,9 @@ pub fn spawn_ai_thread(fps: Arc<AtomicU32>, enabled: Arc<AtomicBool>) {
         }
 
         let filename =
-            std::env::var("BONGO_YOLO_MODEL").unwrap_or_else(|_| "yolov8.onnx".to_string());
-        let repo =
-            std::env::var("BONGO_YOLO_REPO").unwrap_or_else(|_| "ultralytics/yolov8n".to_string());
+            std::env::var("BONGO_YOLO_MODEL").unwrap_or_else(|_| "onnx_model.onnx".to_string());
+        let repo = std::env::var("BONGO_YOLO_REPO")
+            .unwrap_or_else(|_| "NaveenKumar5/Yolov8n-onnx-export".to_string());
         let model_path = if Path::new(&filename).exists() {
             filename.clone()
         } else {


### PR DESCRIPTION
## Summary
- download `onnx_model.onnx` from `NaveenKumar5/Yolov8n-onnx-export`
- document new defaults in README

## Testing
- `nix develop -c cargo fmt`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684d737f79a4832d8a569c9d420383c9