### PR TITLE
Update YOLO model defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - CLI updates are sent to the daemon over a Unix socket
 - `next-image` retrieves frames from the daemon
 - Hyprlock process detection via `--process`
+- Default YOLOv8 model now downloaded from `salim4n/yolov8n-detect-onnx`

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ notes.
 
 To use AI-based FPS modulation, set the `BONGO_YOLO_MODEL` environment variable
 to the desired model filename. If the file does not exist locally the daemon
-automatically downloads it from the Hugging Face hub. The repository can be
-overridden with `BONGO_YOLO_REPO` (defaults to `ultralytics/yolov8n`). The
+automatically downloads it from the Hugging Face hub (defaults to
+`yolov8n-onnx-web/yolov8n.onnx` from `salim4n/yolov8n-detect-onnx`). The repository can
+be overridden with `BONGO_YOLO_REPO`. The
 daemon captures frames with the `nokhwa` crate (camera index `0`) and uses the
 model via the pure-Rust `candle` runtime to estimate how many people are in
 front of the camera. The FPS value is updated based on the detection results.

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -39,10 +39,10 @@ pub fn spawn_ai_thread(fps: Arc<AtomicU32>, enabled: Arc<AtomicBool>) {
             return;
         }
 
-        let filename =
-            std::env::var("BONGO_YOLO_MODEL").unwrap_or_else(|_| "yolov8.onnx".to_string());
-        let repo =
-            std::env::var("BONGO_YOLO_REPO").unwrap_or_else(|_| "ultralytics/yolov8n".to_string());
+        let filename = std::env::var("BONGO_YOLO_MODEL")
+            .unwrap_or_else(|_| "yolov8n-onnx-web/yolov8n.onnx".to_string());
+        let repo = std::env::var("BONGO_YOLO_REPO")
+            .unwrap_or_else(|_| "salim4n/yolov8n-detect-onnx".to_string());
         let model_path = if Path::new(&filename).exists() {
             filename.clone()
         } else {


### PR DESCRIPTION
## Summary
- download `yolov8n-onnx-web/yolov8n.onnx` from `salim4n/yolov8n-detect-onnx`
- document new defaults in README and CHANGELOG

## Testing
- `nix develop -c cargo fmt`
- `nix develop -c cargo clippy -- -D warnings`
- `nix develop -c cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684d737f79a4832d8a569c9d420383c9