### PR TITLE
Switch fps to float range

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -82,15 +82,15 @@ pub fn spawn_ai_thread(fps: Arc<AtomicU32>, enabled: Arc<AtomicBool>) {
             let ratio = (start.elapsed().as_millis() % 1000) as f32 / 1000.0;
             let computed = compute_fps(count, ratio);
             debug!(fps = computed, count, ratio = ratio, "AI updated FPS");
-            fps.store(computed, Ordering::Relaxed);
+            fps.store(computed.to_bits(), Ordering::Relaxed);
             std::thread::sleep(Duration::from_secs(1));
         }
     });
 }
 
-fn compute_fps(count: usize, ratio: f32) -> u32 {
+fn compute_fps(count: usize, ratio: f32) -> f32 {
     let base = 5.0;
     let weight = 20.0;
     let fps = base + weight * ratio * count as f32;
-    fps.clamp(1.0, 60.0) as u32
+    fps.clamp(0.5, 30.0)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,10 @@ pub enum ModeSubcommand {
     /// Enable AI mode (stub)
     Ai,
     /// Set manual FPS
-    Fps { fps: u32 },
+    Fps {
+        #[arg(value_parser = clap::value_parser!(f32))]
+        fps: f32,
+    },
 }
 
 pub fn run_cli() {
@@ -83,8 +86,9 @@ fn enable_ai() {
     info!("AI mode enabled (stub)");
 }
 
-fn set_fps(fps: u32) {
+fn set_fps(fps: f32) {
     let mut cfg = load_config();
+    let fps = fps.clamp(0.5, 30.0);
     cfg.fps = fps;
     cfg.ai_mode = false;
     save_config(&cfg);

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,14 +4,14 @@ use tracing::error;
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
-    pub fps: u32,
+    pub fps: f32,
     pub ai_mode: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            fps: 5,
+            fps: 5.0,
             ai_mode: false,
         }
     }
@@ -48,6 +48,6 @@ pub fn save_config(cfg: &Config) {
 }
 
 /// Returns the currently configured FPS.
-pub fn current_fps() -> u32 {
+pub fn current_fps() -> f32 {
     load_config().fps
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -9,7 +9,7 @@ use std::{env, io};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum ControlMessage {
-    SetFps(u32),
+    SetFps(f32),
     EnableAi,
     NextImage,
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -9,18 +9,20 @@ use tempfile::tempdir;
 
 #[derive(serde::Deserialize, Debug, PartialEq)]
 enum ControlMessage {
-    SetFps(u32),
+    SetFps(f32),
     EnableAi,
     NextImage,
 }
 
 proptest! {
     #[test]
-    fn parse_fps(value in 0u32..1000) {
+    fn parse_fps(value in 0.5f32..30.0f32) {
         let args = ["bongo-modulator", "mode", "fps", &value.to_string()];
         let cli = Cli::parse_from(&args);
         match cli.command {
-            Commands::Mode { mode: ModeSubcommand::Fps { fps } } => prop_assert_eq!(fps, value),
+            Commands::Mode { mode: ModeSubcommand::Fps { fps } } => {
+                prop_assert!((fps - value).abs() < f32::EPSILON)
+            }
             _ => prop_assert!(false, "unexpected subcommand"),
         }
     }
@@ -54,7 +56,7 @@ proptest! {
 
     #[test]
     #[serial]
-    fn execute_sets_fps(value in 1u32..30) {
+    fn execute_sets_fps(value in 0.5f32..30.0f32) {
         let dir = tempdir().unwrap();
         std::env::set_var("BONGO_STATE_PATH", dir.path().join("state.json"));
         let socket = dir.path().join("sock");
@@ -74,8 +76,8 @@ proptest! {
         execute(cli);
 
         let received = handle.join().unwrap();
-        prop_assert_eq!(received, ControlMessage::SetFps(value));
-        prop_assert_eq!(current_fps(), value);
+        prop_assert!(matches!(received, ControlMessage::SetFps(v) if (v - value).abs() < f32::EPSILON));
+        prop_assert!((current_fps() - value).abs() < f32::EPSILON);
         let cfg = load_config();
         prop_assert!(!cfg.ai_mode);
     }


### PR DESCRIPTION
## Summary
- allow fractional fps values
- clamp fps between 0.5 and 30
- update daemon and AI thread for new float fps
- adjust tests for float fps

## Testing
- `cargo clippy -- -D warnings`
- `cargo nextest run`


------
https://chatgpt.com/codex/tasks/task_e_684dcef046e4832d9934c93b629f621b