### PR TITLE
Fix macOS camera fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - `next-image` retrieves frames from the daemon
 - Hyprlock process detection via `--process`
 - Default YOLOv8 model now downloaded from `salim4n/yolov8n-detect-onnx`
+- macOS fallback camera format switched to MJPEG

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -21,7 +21,7 @@ pub fn spawn_ai_thread(fps: Arc<AtomicU32>, enabled: Arc<AtomicBool>) {
         let format = RequestedFormat::new::<RgbFormat>(RequestedFormatType::None);
         #[cfg(target_os = "macos")]
         let fallback = RequestedFormat::new::<RgbFormat>(RequestedFormatType::Closest(
-            CameraFormat::new_from(1280, 720, FrameFormat::NV12, 30),
+            CameraFormat::new_from(1280, 720, FrameFormat::MJPEG, 30),
         ));
         #[cfg(not(target_os = "macos"))]
         let fallback = RequestedFormat::new::<RgbFormat>(RequestedFormatType::Closest(
@@ -40,6 +40,7 @@ pub fn spawn_ai_thread(fps: Arc<AtomicU32>, enabled: Arc<AtomicBool>) {
             error!("failed to open camera stream: {e}");
             return;
         }
+        debug!(format = ?cam.camera_format(), "camera stream opened");
 
         let filename = std::env::var("BONGO_YOLO_MODEL")
             .unwrap_or_else(|_| "yolov8n-onnx-web/yolov8n.onnx".to_string());


### PR DESCRIPTION
## Summary
- switch macOS fallback to MJPEG
- log actual camera format when opening the stream

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` *(fails: `cargo-clippy` not installed in environment)*
- `cargo nextest run` *(fails: network downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ecdf3ce30832d9d09e89f404822b7